### PR TITLE
fix:解决Card组件使用activeScale属性触发手势库后，手势库未初始化导致手势库报错问题

### DIFF
--- a/src/incubator/TouchableOpacity.tsx
+++ b/src/incubator/TouchableOpacity.tsx
@@ -1,5 +1,5 @@
-import React, {PropsWithChildren, useCallback, useMemo} from 'react';
-import {LayoutChangeEvent} from 'react-native';
+import React, { PropsWithChildren, useCallback, useMemo } from 'react';
+import { LayoutChangeEvent } from 'react-native';
 import Reanimated, {
   useAnimatedGestureHandler,
   useAnimatedStyle,
@@ -9,10 +9,10 @@ import Reanimated, {
   interpolateColor,
   runOnJS
 } from 'react-native-reanimated';
-import {TapGestureHandler, LongPressGestureHandler, State} from 'react-native-gesture-handler';
-import {asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps} from '../commons/new';
-import View, {ViewProps} from '../components/view';
-import {Colors} from '../../src/style';
+import { GestureHandlerRootView, TapGestureHandler, LongPressGestureHandler, State } from 'react-native-gesture-handler';
+import { asBaseComponent, forwardRef, BaseComponentInjectedProps, ForwardRefInjectedProps } from '../commons/new';
+import View, { ViewProps } from '../components/view';
+import { Colors } from '../../src/style';
 
 export type TouchableOpacityProps = {
   /**
@@ -80,7 +80,7 @@ function TouchableOpacity(props: Props) {
     activeScale = 1,
     ...others
   } = props;
-  const {borderRadius, paddings, margins, alignments, flexStyle} = modifiers;
+  const { borderRadius, paddings, margins, alignments, flexStyle } = modifiers;
 
   const isActive = useSharedValue(0);
   /* This flag is for fixing an issue with long press triggering twice
@@ -101,7 +101,7 @@ function TouchableOpacity(props: Props) {
 
   const toggleActive = (value: number) => {
     'worklet';
-    isActive.value = withTiming(value, {duration: 200});
+    isActive.value = withTiming(value, { duration: 200 });
   };
 
   const tapGestureHandler = useAnimatedGestureHandler({
@@ -143,39 +143,41 @@ function TouchableOpacity(props: Props) {
         ? backgroundColor
         : interpolateColor(isActive.value, [0, 1], [backgroundColor, activeColor]),
       opacity,
-      transform: [{scale}]
+      transform: [{ scale }]
     };
   }, [backgroundColor, feedbackColor]);
 
   const Container = props.onLongPress ? LongPressGestureHandler : View;
 
   return (
-    <TapGestureHandler
-      onGestureEvent={tapGestureHandler}
-      shouldCancelWhenOutside
-      enabled={!disabled}
-    >
-      <Reanimated.View>
-        <Container onGestureEvent={longPressGestureHandler} shouldCancelWhenOutside>
-          <Reanimated.View
-            {...others}
-            ref={forwardedRef}
-            style={[
-              borderRadius && {borderRadius},
-              flexStyle,
-              paddings,
-              margins,
-              alignments,
-              {backgroundColor},
-              style,
-              animatedStyle
-            ]}
-          >
-            {children}
-          </Reanimated.View>
-        </Container>
-      </Reanimated.View>
-    </TapGestureHandler>
+    <GestureHandlerRootView>
+      <TapGestureHandler
+        onGestureEvent={tapGestureHandler}
+        shouldCancelWhenOutside
+        enabled={!disabled}
+      >
+        <Reanimated.View>
+          <Container onGestureEvent={longPressGestureHandler} shouldCancelWhenOutside>
+            <Reanimated.View
+              {...others}
+              ref={forwardedRef}
+              style={[
+                borderRadius && { borderRadius },
+                flexStyle,
+                paddings,
+                margins,
+                alignments,
+                { backgroundColor },
+                style,
+                animatedStyle
+              ]}
+            >
+              {children}
+            </Reanimated.View>
+          </Container>
+        </Reanimated.View>
+      </TapGestureHandler>
+    </GestureHandlerRootView>
   );
 }
 


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
- 这个功能是什么？（如果适用）
- 您是如何实现解决方案的？
- 这个更改影响了库的哪些部分？

Explain the **motivation** for making this change: here are some points to help you:

- What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
- What is the feature? (if applicable)
- How did you implement the solution?
- What areas of the library does it impact?

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [ ] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
