### PR TITLE
解决 datatimepicker 组件 backgroundColor 属性只对标题位置生效的问题

### DIFF
--- a/src/components/dateTimePicker/index.tsx
+++ b/src/components/dateTimePicker/index.tsx
@@ -287,7 +287,8 @@ const DateTimePicker = forwardRef((props: DateTimePickerPropsInternal, ref: Forw
     return (
       <RNDateTimePicker
         // harmony侧 @react-native-community/datetimepicker 父节点或组件需要设置宽高才进行展示
-        style={Platform.OS as any === 'harmony' ? { width: '100%', height: 240, backgroundColor: '#fff', dateTimePickerStyle } : {}}
+        style={Platform.OS as any === 'harmony' ?
+          { width: '100%', height: 240, backgroundColor: backgroundColor, dateTimePickerStyle } : {}}
         mode={mode}
         value={value || new Date()}
         onChange={handleChange}


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

解决 datatimepicker 组件 backgroundColor 属性只对标题位置生效的问题

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [ ] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
